### PR TITLE
Backend-feat-1-schedule_alarm_by_date

### DIFF
--- a/android/src/main/java/com/baekgol/reactnativealarmmanager/util/AlarmReceiver.java
+++ b/android/src/main/java/com/baekgol/reactnativealarmmanager/util/AlarmReceiver.java
@@ -27,17 +27,5 @@ public class AlarmReceiver extends BroadcastReceiver {
         alarmServiceIntent.putExtra("notiRemovable", intent.getBooleanExtra("notiRemovable", true));
 
         context.startForegroundService(alarmServiceIntent);
-        scheduleNextAlarm(context, intent);
-    }
-
-    private void scheduleNextAlarm(Context context, Intent intent) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(System.currentTimeMillis() + (1000*60*60*24));
-        calendar.set(Calendar.HOUR_OF_DAY, intent.getIntExtra("hour", 1));
-        calendar.set(Calendar.MINUTE, intent.getIntExtra("minute", 1));
-        calendar.set(Calendar.SECOND, 0);
-
-        PendingIntent alarmPendingIntent = PendingIntent.getBroadcast(context, intent.getIntExtra("id", 0), intent, PendingIntent.FLAG_NO_CREATE);
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), alarmPendingIntent);
     }
 }


### PR DESCRIPTION
- [x] Modify the interface to accept the time and date on one object `alarm_time`.
- [x] Calculate the schedule time based on Date and time.
- [x] Refactor the way to get existing alarm, instead of searching by time => searching by ID.
- [x] Disable feature for re-schedule the alarm after ringing for the next day.